### PR TITLE
Added support for Redis ACL

### DIFF
--- a/src/main/java/com/redislabs/springredisearch/RediSearchAutoConfiguration.java
+++ b/src/main/java/com/redislabs/springredisearch/RediSearchAutoConfiguration.java
@@ -26,6 +26,9 @@ public class RediSearchAutoConfiguration {
 		if (properties.getPassword() != null) {
 			redisURI.setPassword(properties.getPassword().toCharArray());
 		}
+		if (properties.getUsername() != null) {
+			redisURI.setUsername(properties.getUsername());
+		}
 		Duration timeout = properties.getTimeout();
 		if (timeout != null) {
 			redisURI.setTimeout(timeout);


### PR DESCRIPTION
Added support for Redis ACL so username can be passed. Without it the connection is unsuccessful. The username is always set to _default_ no matter what the user is passing